### PR TITLE
feat(layout): improves forgot password screens

### DIFF
--- a/app/controllers/passwords_controller.rb
+++ b/app/controllers/passwords_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class PasswordsController < ApplicationController
+  layout 'authentication'
+
   allow_unauthenticated_access
 
   before_action :set_user_by_token, only: %i[edit update]

--- a/app/views/passwords/edit.html.erb
+++ b/app/views/passwords/edit.html.erb
@@ -1,9 +1,24 @@
-<h1>Update your password</h1>
+<div class="flex flex-col justify-center items-center px-6 pt-8 mx-auto md:h-screen pt:mt-0">
+  <div class="w-full max-w-sm p-4 bg-white border border-gray-200 rounded-lg shadow-sm sm:p-6 md:p-8 dark:bg-gray-800 dark:border-gray-700">
+    <div class="space-y-8">
+      <h2 class="text-xl font-medium text-gray-900 dark:text-white">
+        Update your password
+      </h2>
 
-<%= tag.div(flash[:alert], style: "color:red") if flash[:alert] %>
+      <%= tag.div(flash[:alert], class: 'p-4 mb-4 text-sm text-red-800 rounded-lg bg-red-50 dark:bg-gray-800 dark:text-red-400', role: 'alert') if flash[:alert] %>
 
-<%= form_with url: password_path(params[:token]), method: :put do |form| %>
-  <%= form.password_field :password, required: true, autocomplete: "new-password", placeholder: "Enter new password", maxlength: 72 %><br>
-  <%= form.password_field :password_confirmation, required: true, autocomplete: "new-password", placeholder: "Repeat new password", maxlength: 72 %><br>
-  <%= form.submit "Save" %>
-<% end %>
+      <%= form_with url: password_path(params[:token]), method: :put, class: 'space-y-6' do |form| %>
+        <div>
+          <%= form.label :password, class: 'block mb-2 text-sm font-medium text-gray-900 dark:text-white' %>
+          <%= form.password_field :password, required: true, autocomplete: 'new-password', placeholder: 'Enter new password', maxlength: 72, class: 'bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 dark:bg-gray-600 dark:border-gray-500 dark:placeholder-gray-400 dark:text-white' %>
+        </div>
+        <div>
+          <%= form.label :password_confirmation, class: 'block mb-2 text-sm font-medium text-gray-900 dark:text-white' %>
+          <%= form.password_field :password_confirmation, required: true, autocomplete: 'new-password', placeholder: 'Repeat new password', maxlength: 72, class: 'bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 dark:bg-gray-600 dark:border-gray-500 dark:placeholder-gray-400 dark:text-white' %>
+        </div>
+
+        <%= form.submit 'Save', class: 'w-full text-white bg-blue-700 hover:bg-blue-800 focus:ring-4 focus:outline-none focus:ring-blue-300 font-medium rounded-lg text-sm px-5 py-2.5 text-center dark:bg-blue-600 dark:hover:bg-blue-700 dark:focus:ring-blue-800' %>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/passwords/new.html.erb
+++ b/app/views/passwords/new.html.erb
@@ -1,8 +1,20 @@
-<h1>Forgot your password?</h1>
+<div class="flex flex-col justify-center items-center px-6 pt-8 mx-auto md:h-screen pt:mt-0">
+  <div class="w-full max-w-sm p-4 bg-white border border-gray-200 rounded-lg shadow-sm sm:p-6 md:p-8 dark:bg-gray-800 dark:border-gray-700">
+    <div class="space-y-8">
+      <h2 class="text-xl font-medium text-gray-900 dark:text-white">
+        Forgot your password?
+      </h2>
 
-<%= tag.div(flash[:alert], style: "color:red") if flash[:alert] %>
+      <%= tag.div(flash[:alert], class: 'p-4 mb-4 text-sm text-red-800 rounded-lg bg-red-50 dark:bg-gray-800 dark:text-red-400', role: 'alert') if flash[:alert] %>
 
-<%= form_with url: passwords_path do |form| %>
-  <%= form.email_field :email, required: true, autofocus: true, autocomplete: "username", placeholder: "Enter your email address", value: params[:email] %><br>
-  <%= form.submit "Email reset instructions" %>
-<% end %>
+      <%= form_with url: passwords_path, class: 'space-y-6' do |form| %>
+        <div>
+          <%= form.label :email, class: 'block mb-2 text-sm font-medium text-gray-900 dark:text-white' %>
+          <%= form.email_field :email, required: true, autofocus: true, autocomplete: 'username', placeholder: 'Enter your email address', value: params[:email], class: 'bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 dark:bg-gray-600 dark:border-gray-500 dark:placeholder-gray-400 dark:text-white' %>
+        </div>
+
+        <%= form.submit 'Send email with reset instructions', class: 'w-full text-white bg-blue-700 hover:bg-blue-800 focus:ring-4 focus:outline-none focus:ring-blue-300 font-medium rounded-lg text-sm px-5 py-2.5 text-center dark:bg-blue-600 dark:hover:bg-blue-700 dark:focus:ring-blue-800' %>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/config/locales/controllers.yml
+++ b/config/locales/controllers.yml
@@ -2,6 +2,8 @@ en:
   passwords:
     create:
       success: 'Password reset instructions sent (if user with that email address exists).'
+    edit:
+      failed: 'Password reset link is invalid or has expired.'
     update:
       success: 'Password has been reset.'
       failed: 'Passwords did not match.'

--- a/spec/system/forgot_password_spec.rb
+++ b/spec/system/forgot_password_spec.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Forgot password', type: :system do
+  fixtures :users
+
+  before { driven_by(:rack_test) }
+
+  describe 'Request password reset' do
+    it 'redirects to sign in' do
+      visit '/passwords/new'
+
+      fill_in 'Email', with: 'one@example.com'
+      click_button 'Send email with reset instructions'
+
+      expect(page).to have_current_path('/session/new')
+    end
+
+    it 'renders successful message' do
+      visit '/passwords/new'
+
+      fill_in 'Email', with: 'one@example.com'
+      click_button 'Send email with reset instructions'
+
+      expect(page).to have_content('Password reset instructions sent (if user with that email address exists).')
+    end
+
+    it 'deliveries email when user exists' do
+      visit '/passwords/new'
+
+      fill_in 'Email', with: 'one@example.com'
+
+      expect { click_button 'Send email with reset instructions' }.to have_enqueued_job.exactly(1).times
+    end
+
+    it 'does not deliver email when user not exists' do
+      visit '/passwords/new'
+
+      fill_in 'Email', with: 'not-found@example.com'
+
+      expect { click_button 'Send email with reset instructions' }.not_to have_enqueued_job
+    end
+  end
+
+  describe 'Update password' do
+    it 'renders successful message' do
+      visit "/passwords/#{users(:one).password_reset_token}/edit"
+
+      fill_in 'Password', with: '123456'
+      fill_in 'Password confirmation', with: '123456'
+      click_button 'Save'
+
+      expect(page).to have_content('Password has been reset.')
+    end
+
+    it 'redirects to sign in' do
+      visit "/passwords/#{users(:one).password_reset_token}/edit"
+
+      fill_in 'Password', with: '123456'
+      fill_in 'Password confirmation', with: '123456'
+      click_button 'Save'
+
+      expect(page).to have_current_path('/session/new')
+    end
+
+    it 'renders error message when token is invalid' do
+      visit '/passwords/invalid-token/edit'
+
+      expect(page).to have_content('Password reset link is invalid or has expired.')
+    end
+
+    it 'renders error message when passwords does not match' do
+      visit "/passwords/#{users(:one).password_reset_token}/edit"
+
+      fill_in 'Password', with: 'new-password'
+      fill_in 'Password confirmation', with: 'new-password-mismatch'
+      click_button 'Save'
+
+      expect(page).to have_content('Passwords did not match')
+    end
+  end
+end


### PR DESCRIPTION
## New design for forgot password

<img width="509" alt="image" src="https://github.com/user-attachments/assets/d869b386-c2a2-42ac-9d9f-98c8aa50d768" />

## New design for update password

<img width="591" alt="image" src="https://github.com/user-attachments/assets/ee5c0f37-e38f-4e02-b4e2-1db98e37ce5a" />


## After update password

<img width="590" alt="image" src="https://github.com/user-attachments/assets/d1739f59-4de0-4891-8ebb-62f3b27c9387" />
